### PR TITLE
Fix branch

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -74,7 +74,7 @@ func createMetadataJson(in input) string {
 	branch := in.branch
 	actions.Infof("GITHUB_HEAD_REF %v\n", os.Getenv("GITHUB_HEAD_REF"))
 	actions.Infof("GITHUB_REF %v\n", os.Getenv("GITHUB_REF"))
-	if branch == "" && os.Getenv("GITHUB_HEAD_REF") == "" {
+	if branch == "" && os.Getenv("GITHUB_HEAD_REF") == "" &&  strings.Contains(os.Getenv("GITHUB_REF"), "refs/heads/"){
 		branch = "main"
 	} else {
 		branch = strings.TrimSuffix(os.Getenv("GITHUB_REF"), "refs/heads/")


### PR DESCRIPTION
there are some cases where `GITHUB_HEAD_REF` and `GITHUB_REF` values are set differently for PR, branch vs the main branch. This was resulting in the branch value being set to the wrong branch in the metadata file. Now this should be fixed 

<img width="250" alt="Screen Shot 2021-10-06 at 3 06 55 PM" src="https://user-images.githubusercontent.com/5048814/136465295-a64571e3-a2da-49ef-8ab2-7d2e27be9a7c.png">
<img width="433" alt="Screen Shot 2021-10-07 at 2 14 28 PM" src="https://user-images.githubusercontent.com/5048814/136465298-6aa876c7-d409-4e25-8a68-27eacf173309.png">
<img width="220" alt="Screen Shot 2021-10-06 at 3 07 01 PM" src="https://user-images.githubusercontent.com/5048814/136465294-72651266-d1b3-4f96-9045-143427cf0652.png">

