### PR TITLE
Add optional sha param

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -42,8 +42,9 @@ jobs:
           version: make -f tests/Makefile version
           product: ${{ github.event.repository.name }}
           sha: "6064764fb6b6213724fa55ce0fe737362ab97a12"
+          metadataFileName: "metadata-sha-test.json"
 
       - uses: actions/upload-artifact@v2
         with:
-          name: metadata.json
+          name: metadata-sha-test.json
           path: ${{ steps.generate_metadata.outputs.filepath }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -7,7 +7,7 @@ on:
       - LICENSE
 
 jobs:
-  action-run:
+  action-test-default:
     runs-on: ubuntu-latest
     outputs:
       filepath: ${{ steps.action-run.outputs.filepath }}
@@ -21,6 +21,27 @@ jobs:
           repository: ${{ github.event.repository.name }}
           version: make -f tests/Makefile version
           product: ${{ github.event.repository.name }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: metadata.json
+          path: ${{ steps.generate_metadata.outputs.filepath }}
+          
+  action-test-provide-sha:
+    runs-on: ubuntu-latest
+    outputs:
+      filepath: ${{ steps.action-run.outputs.filepath }}
+    steps:
+      - name: 'Checkout directory'
+        uses: actions/checkout@v2
+      - name: Generate metadata file
+        id: generate_metadata
+        uses: ./
+        with:
+          repository: ${{ github.event.repository.name }}
+          version: make -f tests/Makefile version
+          product: ${{ github.event.repository.name }}
+          sha: "6064764fb6b6213724fa55ce0fe737362ab97a12"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   version:
     description: 'Version or version command (e.g: make version)'
     required: true
+  sha:
+    description: 'The build commit sha'
+    required: false
+    
 
 runs:
   using: docker


### PR DESCRIPTION
### Justification

https://github.com/hashicorp/nomad/pull/12781#discussion_r858519733

### Summary

Provide ability to pass the build sha to the action - in the case that the build workflow is being called as a reusable workflow and the build sha differs from GITHUB_SHA.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [x] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_