### PR TITLE
initial commit of getArtifacts function

### DIFF
--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -83,7 +83,7 @@ func extractProductName(rawArtifactName string) string {
 	// cases. Finally, we return the match minus the arch/file extenion.
 	productName := ""
 	// RPMs use a . instead of a _ to delinate their extentions.
-	if strings.Contains(rawArtifactName, "rpm") {
+	if strings.HasSuffix(rawArtifactName, "rpm") {
 		re := regexp.MustCompile(`^.*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?[^\.]*`)
 		productName = re.FindString(rawArtifactName)
 		productName = correctProductNameRPM(productName)
@@ -104,11 +104,7 @@ func extractProductName(rawArtifactName string) string {
 
 	// Some artifact names have a -1 after the semver, we want to remove that for our product
 	// name.
-	if len(productName) > 1 {
-		if productName[len(productName)-2:] == "-1" {
-			productName = productName[:len(productName)-2]
-		}
-	}
+	productName = strings.TrimSuffix(productName, "-1")
 
 	return productName
 }

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// getArtifacts queries github for artifact list, returning a 2 dimensional slice of
+// getArtifacts queries github for artifact list, returning a map of strings of
 // artifact names paired with their variant type.
 // org, repo, and workflowrunID are the github vars passed in to the API for the
 // workflow run query, see: https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -56,12 +56,8 @@ func getArtifacts(org string, repo string, workflowRunID int64) map[string][]str
 	}
 
 	// Parse raw list of artifact names into struct of Artifacts and variant names.
-	// For Vault products, associate variant types with their artifacts. All other products
-	// do not require variant grouping and thus are associated with variant type "all".
+	// Some builds include files that are not build artifacts; we weed those out here.
 	processedArtifacts := make(map[string][]string)
-
-	// for all other products, we don't need to sort variants, but some builds include
-	// metadata files in their artifacts - this removes those from our final list.
 	for i := range rawArtifacts {
 		switch {
 		case strings.Contains(rawArtifacts[i], ".json") || strings.Contains(rawArtifacts[i], ".sig") ||

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/sethvargo/go-githubactions"
+	"golang.org/x/oauth2"
+)
+
+// getArtifacts queries github for artifact list, returning a 2 dimensional slice of
+// artifact names paired with their variant type.
+// repo expects name of the product as it appears in its artifacts
+// as completely as possible, for example, "vault" for oss vault and "vault-enterprise"
+// for enterprise vault.
+func getArtifacts(org string, repo string, workflowRunID int64) [][]string {
+
+	// Auth to github API.
+	token := os.Getenv("CRT_GITHUB_TOKEN")
+	if token == "" {
+		githubactions.Errorf("missing env CRT_GITHUB_TOKEN")
+	}
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	ghClient := github.NewClient(tc)
+
+	// Query API for list of artifacts associated with specified build workflow of product.
+	artifacts, _, err := ghClient.Actions.ListWorkflowRunArtifacts(ctx, org, repo, workflowRunID, &github.ListOptions{})
+	if err != nil {
+		githubactions.Errorf(err)
+	}
+
+	// Extract a list of artifact names from the artifact data structure returned from the
+	// github API.
+	var rawArtifacts []string
+	for i := range artifacts.Artifacts {
+		rawArtifacts = append(rawArtifacts, *artifacts.Artifacts[i].Name)
+	}
+
+	// Parse raw list of artifact names into struct of Artifacts and variant names.
+	// For Vault products, associate variant types with their artifacts, all other products
+	// do not require variant grouping and thus are associated with variant type "all".
+	var processedArtifacts [][]string
+	if repo == "vault-enterprise" {
+		for i := range rawArtifacts {
+			switch {
+			case strings.Contains(rawArtifacts[i], "ent.hsm.fips"):
+				processedArtifacts = append(processedArtifacts, []string{"ent.hsm.fips", rawArtifacts[i]})
+			case strings.Contains(rawArtifacts[i], "ent.fips"):
+				processedArtifacts = append(processedArtifacts, []string{"ent.fips", rawArtifacts[i]})
+			case strings.Contains(rawArtifacts[i], "ent.hsm"):
+				processedArtifacts = append(processedArtifacts, []string{"ent.hsm", rawArtifacts[i]})
+			case strings.Contains(rawArtifacts[i], "ent"):
+				processedArtifacts = append(processedArtifacts, []string{"ent", rawArtifacts[i]})
+			default:
+				githubactions.Infof("File %v does not match any expected pattern.", rawArtifacts[i])
+			}
+		}
+	} else if repo == "consul-k8s" {
+		for i := range rawArtifacts {
+			switch {
+			case strings.Contains(rawArtifacts[i], "consul-k8s-control-plane"):
+				processedArtifacts = append(processedArtifacts, []string{"consul-k8s-control-plane", rawArtifacts[i]})
+			case strings.Contains(rawArtifacts[i], "consul-k8s"):
+				processedArtifacts = append(processedArtifacts, []string{"consul-k8s", rawArtifacts[i]})
+			default:
+				githubactions.Infof("File %v does not match any expected pattern.", rawArtifacts[i])
+			}
+		}
+	} else {
+		// for all other products, we don't need to sort variants, but some builds include
+		// metadata files in their artifacts - this removes those from our final list.
+		for i := range rawArtifacts {
+			switch {
+			case strings.Contains(rawArtifacts[i], ".json") || strings.Contains(rawArtifacts[i], ".sig") ||
+				strings.Contains(rawArtifacts[i], "_SHA256SUMS"):
+				githubactions.Infof("File %v does not match any expected pattern.", rawArtifacts[i])
+			default:
+				processedArtifacts = append(processedArtifacts, []string{"all", rawArtifacts[i]})
+			}
+		}
+	}
+
+	return processedArtifacts
+}

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -49,9 +49,9 @@ func getArtifacts(org string, repo string, workflowRunID int64) map[string][]str
 	// Extract a list of artifact names from the artifact data structure returned from the
 	// github API.
 	var rawArtifacts []string
-	for i := range artifacts {
-		for j := range artifacts[i].Artifacts {
-			rawArtifacts = append(rawArtifacts, *artifacts[i].Artifacts[j].Name)
+	for _, ghArtifact := range artifacts {
+		for _, artifact := range ghArtifact.Artifacts {
+			rawArtifacts = append(rawArtifacts, *artifact.Name)
 		}
 	}
 

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/google/go-github/v45/github"
@@ -14,7 +16,7 @@ import (
 // artifact names paired with their variant type.
 // org, repo, and workflowrunID are the github vars passed in to the API for the
 // workflow run query, see: https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts
-func getArtifacts(org string, repo string, workflowRunID int64) [][]string {
+func getArtifacts(org string, repo string, workflowRunID int64) map[string][]string {
 
 	// Auth to github API.
 	token := os.Getenv("CRT_GITHUB_TOKEN")
@@ -32,7 +34,7 @@ func getArtifacts(org string, repo string, workflowRunID int64) [][]string {
 	// Query API for list of artifacts associated with specified build workflow of product.
 	artifacts, _, err := ghClient.Actions.ListWorkflowRunArtifacts(ctx, org, repo, workflowRunID, &github.ListOptions{})
 	if err != nil {
-		githubactions.Errorf(err)
+		fmt.Println(err)
 	}
 
 	// Extract a list of artifact names from the artifact data structure returned from the
@@ -45,46 +47,124 @@ func getArtifacts(org string, repo string, workflowRunID int64) [][]string {
 	// Parse raw list of artifact names into struct of Artifacts and variant names.
 	// For Vault products, associate variant types with their artifacts. All other products
 	// do not require variant grouping and thus are associated with variant type "all".
-	var processedArtifacts [][]string
-	if repo == "vault-enterprise" {
-		for i := range rawArtifacts {
-			switch {
-			case strings.Contains(rawArtifacts[i], "ent.hsm.fips"):
-				processedArtifacts = append(processedArtifacts, []string{"ent.hsm.fips", rawArtifacts[i]})
-			case strings.Contains(rawArtifacts[i], "ent.fips"):
-				processedArtifacts = append(processedArtifacts, []string{"ent.fips", rawArtifacts[i]})
-			case strings.Contains(rawArtifacts[i], "ent.hsm"):
-				processedArtifacts = append(processedArtifacts, []string{"ent.hsm", rawArtifacts[i]})
-			case strings.Contains(rawArtifacts[i], "ent"):
-				processedArtifacts = append(processedArtifacts, []string{"ent", rawArtifacts[i]})
-			default:
-				githubactions.Infof("File %v does not match any expected pattern.", rawArtifacts[i])
-			}
-		}
-	} else if repo == "consul-k8s" {
-		for i := range rawArtifacts {
-			switch {
-			case strings.Contains(rawArtifacts[i], "consul-k8s-control-plane"):
-				processedArtifacts = append(processedArtifacts, []string{"consul-k8s-control-plane", rawArtifacts[i]})
-			case strings.Contains(rawArtifacts[i], "consul-k8s"):
-				processedArtifacts = append(processedArtifacts, []string{"consul-k8s", rawArtifacts[i]})
-			default:
-				githubactions.Infof("File %v does not match any expected pattern.", rawArtifacts[i])
-			}
-		}
-	} else {
-		// for all other products, we don't need to sort variants, but some builds include
-		// metadata files in their artifacts - this removes those from our final list.
-		for i := range rawArtifacts {
-			switch {
-			case strings.Contains(rawArtifacts[i], ".json") || strings.Contains(rawArtifacts[i], ".sig") ||
-				strings.Contains(rawArtifacts[i], "_SHA256SUMS"):
-				githubactions.Infof("File %v does not match any expected pattern.", rawArtifacts[i])
-			default:
-				processedArtifacts = append(processedArtifacts, []string{"all", rawArtifacts[i]})
-			}
+	processedArtifacts := make(map[string][]string)
+
+	// for all other products, we don't need to sort variants, but some builds include
+	// metadata files in their artifacts - this removes those from our final list.
+	for i := range rawArtifacts {
+		switch {
+		case strings.Contains(rawArtifacts[i], ".json") || strings.Contains(rawArtifacts[i], ".sig") ||
+			strings.Contains(rawArtifacts[i], "_SHA256SUMS"):
+			githubactions.Infof("File %v does not match any expected pattern.", rawArtifacts[i])
+		default:
+			productName := extractProductName(rawArtifacts[i])
+			processedArtifacts[productName] = append(processedArtifacts[productName], rawArtifacts[i])
 		}
 	}
 
 	return processedArtifacts
+}
+
+// extractProductName accepts an artifact name, ie. "product_1.2.3-ent_amd64.deb" and
+// returns a string containing the name/version of the product, ie. "product_1.2.3-ent"
+func extractProductName(rawArtifactName string) string {
+	// Extract the product name and relevant extentions with a big ugly regex. Basically,
+	// these regexes look for the semver in their input string, then search for a delimater
+	// between the variant strings that follow semver (-dev, +ent, +ent.hsm, etc.) and the
+	// architecture/file exention. The specifics of this search vary a little for a few special
+	// cases. Finally, we return the match minus the arch/file extenion.
+	productName := ""
+	// RPMs use a . instead of a _ to delinate their extentions.
+	if strings.Contains(rawArtifactName, "rpm") {
+		re := regexp.MustCompile(`^.*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?[^\.]*`)
+		productName = re.FindString(rawArtifactName)
+		productName = correctProductNameRPM(productName)
+	} else if strings.Contains(rawArtifactName, "docker") {
+		re := regexp.MustCompile(`^.*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?[^_]*`)
+		productName = re.FindString(rawArtifactName)
+		productName = correctProductNameDocker(productName)
+	} else {
+		re := regexp.MustCompile(`^.*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?[^_]*`)
+		productName = re.FindString(rawArtifactName)
+	}
+
+	// We need to do some post-processing to make the product name we use in our data more
+	// consistent than the product names we have in our artifacts:
+	// some files use ~ instead of - in their product text, we replace here as we want product
+	// names to stick to the - format.
+	productName = strings.ReplaceAll(productName, "~", "-")
+
+	// Some artifact names have a -1 after the semver, we want to remove that for our product
+	// name.
+	if len(productName) > 1 {
+		if productName[len(productName)-2:] == "-1" {
+			productName = productName[:len(productName)-2]
+		}
+	}
+
+	return productName
+}
+
+// Docker filenames look something like "product_default_amd_linux_386_1.2.3-dev".
+// correctProductNameDocker parses these names and returns a product name which fits
+// the norms for our other artifacts, such as "product_1.2.3-dev" for the example.
+func correctProductNameDocker(productName string) string {
+	// List of strings indicitive of docker cruft - add new strings here if a team
+	// changes their docker naming and their artifacts aren't getting caught.
+	// Map of structs is a little odd looking, but allows easy lookups as we loop
+	// through the terms in productName, preventing an On^2 loop.
+	var dockerExceptions = map[string]struct{}{
+		"default": {}, "release": {}, "release-default": {}, "ubi": {},
+	}
+	// Split the original string along the delimeter "_", then loop through 1 word at a time.
+	substrings := strings.Split(productName, "_")
+	var newProductName string
+	for i, word := range substrings {
+		// When we find a term that signifies docker filename cruft, loop through the
+		// remainder of the list looking for the semver and setting anything else to an
+		// empty string. When we find the semver, break out of this loop.
+		if _, ok := dockerExceptions[word]; ok {
+			for j := i; j < len(substrings); j++ {
+				re := regexp.MustCompile(`(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?[^_]*`)
+				found := re.MatchString(substrings[j])
+				if found {
+					break
+				} else {
+					substrings[j] = ""
+				}
+			}
+		}
+		// build a new string from the current substring index, ignoring empty strings and
+		// re-inserting the _ which we removed as a delimeter.
+		if i == 0 {
+			newProductName += substrings[i]
+		} else if substrings[i] != "" {
+			newProductName = newProductName + "_" + substrings[i]
+		}
+	}
+
+	return newProductName
+}
+
+// rpms use a - instead of an _ as the delimeter before the semver. This changes it to
+// "_" for consistency.
+func correctProductNameRPM(productName string) string {
+	// Solving this required some hard to read logic, documenting heavily for readability:
+	// Create a regex that finds a substring from start of string through semver.
+	re := regexp.MustCompile(`^.*-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)`)
+	// Break the product name into 2 halves with semver as a fulcrum. This produces 2
+	// halves that look something like: "product-1.2.3" and "-dev-1" or
+	// "product-1.2.3" and "".
+	prefixString := strings.Join(re.FindAllString(productName, -1), "")
+	postfixString := strings.Join(re.Split(productName, -1), "")
+	// Find the last "-" in the prefix substring, verify that it exists, and rebuild the
+	// prefix string around that index replacing "-" with "_"
+	charIndex := strings.LastIndex(prefixString, "-")
+	if charIndex > 0 {
+		prefixString = prefixString[:charIndex] + "_" + prefixString[charIndex+1:]
+	} else {
+		githubactions.Warningf("Attempt to correct RPM product name for consistency failed.")
+	}
+	// rebuild the original product name using the modified prefix.
+	return prefixString + postfixString
 }

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -19,9 +19,9 @@ import (
 func getArtifacts(org string, repo string, workflowRunID int64) map[string][]string {
 
 	// Auth to github API.
-	token := os.Getenv("CRT_GITHUB_TOKEN")
+	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
-		githubactions.Errorf("missing env CRT_GITHUB_TOKEN")
+		githubactions.Fatalf("missing env GITHUB_TOKEN")
 	}
 
 	ctx := context.Background()

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -136,8 +136,8 @@ func correctProductNameDocker(productName string) string {
 		// remainder of the list looking for the semver and setting anything else to an
 		// empty string. When we find the semver, break out of this loop.
 		if _, ok := dockerExceptions[word]; ok {
+			re := regexp.MustCompile(`(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?[^_]*`)
 			for j := i; j < len(substrings); j++ {
-				re := regexp.MustCompile(`(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?[^_]*`)
 				found := re.MatchString(substrings[j])
 				if found {
 					break

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -12,9 +12,8 @@ import (
 
 // getArtifacts queries github for artifact list, returning a 2 dimensional slice of
 // artifact names paired with their variant type.
-// repo expects name of the product as it appears in its artifacts
-// as completely as possible, for example, "vault" for oss vault and "vault-enterprise"
-// for enterprise vault.
+// org, repo, and workflowrunID are the github vars passed in to the API for the
+// workflow run query, see: https://docs.github.com/en/rest/actions/artifacts#list-workflow-run-artifacts
 func getArtifacts(org string, repo string, workflowRunID int64) [][]string {
 
 	// Auth to github API.
@@ -44,7 +43,7 @@ func getArtifacts(org string, repo string, workflowRunID int64) [][]string {
 	}
 
 	// Parse raw list of artifact names into struct of Artifacts and variant names.
-	// For Vault products, associate variant types with their artifacts, all other products
+	// For Vault products, associate variant types with their artifacts. All other products
 	// do not require variant grouping and thus are associated with variant type "all".
 	var processedArtifacts [][]string
 	if repo == "vault-enterprise" {

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -32,8 +32,8 @@ func getArtifacts(org string, repo string, workflowRunID int64) map[string][]str
 	ghClient := github.NewClient(tc)
 
 	// Query API for list of artifacts associated with specified build workflow of product.
-	opt := &github.ListOptions{PerPage: 100}
-	var artifacts []*github.ArtifactList
+	opt := &github.ListOptions{PerPage: 100} // 100 is max resposes per page.
+	var artifacts []*github.ArtifactList     // each page of results is an element in array.
 	for {
 		artifactPage, response, err := ghClient.Actions.ListWorkflowRunArtifacts(ctx, org, repo, workflowRunID, opt)
 		if err != nil {

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -19,9 +19,9 @@ import (
 func getArtifacts(org string, repo string, workflowRunID int64) map[string][]string {
 
 	// Auth to github API.
-	token := os.Getenv("CRT_GITHUB_TOKEN")
+	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
-		githubactions.Errorf("missing env CRT_GITHUB_TOKEN")
+		githubactions.Errorf("missing env GITHUB_TOKEN")
 	}
 
 	ctx := context.Background()

--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -65,7 +65,9 @@ func getArtifacts(org string, repo string, workflowRunID int64) map[string][]str
 			githubactions.Infof("File %v does not match any expected pattern.", rawArtifacts[i])
 		default:
 			productName := extractProductName(rawArtifacts[i])
-			processedArtifacts[productName] = append(processedArtifacts[productName], rawArtifacts[i])
+			if productName != "" {
+				processedArtifacts[productName] = append(processedArtifacts[productName], rawArtifacts[i])
+			}
 		}
 	}
 

--- a/action/metadata-support_test.go
+++ b/action/metadata-support_test.go
@@ -41,6 +41,8 @@ func TestExtractProductName(t *testing.T) {
 			name:     "consul-enterprise_default_linux_386_1.13.0-dev+ent_4700797934aaf631edfeeb58ede73e6484778492.docker.dev.tar",
 			expected: "consul-enterprise_1.13.0-dev+ent",
 		},
+
+		// consul k8s test cases, verifies that control-plane correctly slots into its own variant
 		{ // consul k8s
 			name:     "consul-k8s_0.46.0_windows_amd64.zip",
 			expected: "consul-k8s_0.46.0",
@@ -49,6 +51,9 @@ func TestExtractProductName(t *testing.T) {
 			name:     "consul-k8s-control-plane_0.46.0_darwin_arm64.zip",
 			expected: "consul-k8s-control-plane_0.46.0",
 		},
+
+		// vault test cases, checking both OSS and all of the possible variants of
+		// vault enterprise (hsm, fips, hsm.fips, etc)
 		{ // regular ol vault dev with some rpm edge cases
 			name:     "vault-1.12.0~dev1-1.armv7hl.rpm",
 			expected: "vault_1.12.0-dev1",

--- a/action/metadata-support_test.go
+++ b/action/metadata-support_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractProductName(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+	}{
+		// consul test cases, verifies consistency for product without variants, including
+		// edge cases for rpms and docker artifact names.
+		{ // consul dev deb
+			name:     "consul_1.13.0~dev-1_arm64.deb",
+			expected: "consul_1.13.0-dev",
+		},
+		{ // consul release deb
+			name:     "consul_1.11.3_arm64.deb",
+			expected: "consul_1.11.3",
+		},
+		{ // consul dev rpm
+			name:     "consul-1.13.0~dev-1.aarch64.rpm",
+			expected: "consul_1.13.0-dev",
+		},
+		{ // consul release rpm
+			name:     "consul-1.11.3.x86_64.rpm",
+			expected: "consul_1.11.3",
+		},
+		{ // consul dev docker
+			name:     "consul_default_linux_amd64_1.13.0-dev_77afe0e76e03f6f88376a99936945c0a70e544ac.docker.dev.tar",
+			expected: "consul_1.13.0-dev",
+		},
+		{ // consul release docker
+			name:     "consul_default_linux_amd64_1.11.3_36e73cdb6550d4e2cea7548e90ac2b531181ff9d.docker.tar",
+			expected: "consul_1.11.3",
+		},
+		{ // verify the "-" in consul-enterprise is working as expected
+			name:     "consul-enterprise_default_linux_386_1.13.0-dev+ent_4700797934aaf631edfeeb58ede73e6484778492.docker.dev.tar",
+			expected: "consul-enterprise_1.13.0-dev+ent",
+		},
+		{ // consul k8s
+			name:     "consul-k8s_0.46.0_windows_amd64.zip",
+			expected: "consul-k8s_0.46.0",
+		},
+		{ // consul k8s control plane
+			name:     "consul-k8s-control-plane_0.46.0_darwin_arm64.zip",
+			expected: "consul-k8s-control-plane_0.46.0",
+		},
+		{ // regular ol vault dev with some rpm edge cases
+			name:     "vault-1.12.0~dev1-1.armv7hl.rpm",
+			expected: "vault_1.12.0-dev1",
+		},
+		{ // vault ent dev
+			name:     "vault_1.12.0-dev1+ent_openbsd_arm.zip",
+			expected: "vault_1.12.0-dev1+ent",
+		},
+		{ // vault ent dev fips
+			name:     "vault_1.12.0-dev1+ent.fips1402_linux_amd64.zip",
+			expected: "vault_1.12.0-dev1+ent.fips1402",
+		},
+		{ // vault ent dev hsm
+			name:     "vault_1.12.0-dev1+ent.hsm_linux_amd64.zip",
+			expected: "vault_1.12.0-dev1+ent.hsm",
+		},
+		{ // vault ent dev hsm fips
+			name:     "vault_1.12.0-dev1+ent.hsm.fips1402_linux_amd64.zip",
+			expected: "vault_1.12.0-dev1+ent.hsm.fips1402",
+		},
+		{ // vault-enterprise dev
+			name:     "vault-enterprise-1.12.0~dev1+ent-1.armv7hl.rpm",
+			expected: "vault-enterprise_1.12.0-dev1+ent",
+		},
+		{ // vault-enterprise dev hsm
+			name:     "vault-enterprise-hsm-1.12.0~dev1+ent-1.x86_64.rpm",
+			expected: "vault-enterprise-hsm_1.12.0-dev1+ent",
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expected, extractProductName(c.name))
+	}
+
+}


### PR DESCRIPTION
### Justification
https://hashicorp.atlassian.net/browse/RDX-564

### Summary

This adds a function that queries the github API for a list of artifacts associated with a specific workflow run, then parses those artifacts by name and variant (when required by a specific product), removes non-artifact files, and returns a 2 dimensional array of paired artifact names and variants. 

For ease of review, I will integrate this into the existing actions code in a future PR.

As the conditions for detecting a specific build variant of a product are brittle and non-unique (ie "ent.hsm" contains "ent", both of which are valid strings by which to detect a variant), I chose to go with the switch statement structure seen here for parsing rather than abstract a function that generalized this work with an arbitrary array of variants. The later would have either required the user of the function to be deliberate about the order of items in the array of variants, or contained an inordinately complex tool for detecting and resolving these sorts of overlaps.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ x] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_
 
example output when run against https://github.com/hashicorp/vault-enterprise/actions/runs/2670212683:

File docker_tag_list_default.json does not match any expected pattern.
File docker_tag_list_ubi.json does not match any expected pattern.
File docker_tag_list_ubi_redhat.json does not match any expected pattern.
File docker_tag_list_ubi-fips_redhat.json does not match any expected pattern.
File metadata.json does not match any expected pattern.
{"Artifacts":[["ent.fips","vault_1.12.0-dev1+ent.fips1402_linux_amd64.zip"],["ent.hsm.fips","vault_1.12.0-dev1+ent.hsm.fips1402_linux_amd64.zip"],["ent.hsm","vault_1.12.0-dev1+ent.hsm_linux_amd64.zip"],["ent","vault_1.12.0-dev1+ent_darwin_amd64.zip"],["ent","vault_1.12.0-dev1+ent_darwin_arm64.zip"],["ent","vault_1.12.0-dev1+ent_freebsd_386.zip"],["ent","vault_1.12.0-dev1+ent_freebsd_amd64.zip"],["ent","vault_1.12.0-dev1+ent_freebsd_arm.zip"],["ent","vault_1.12.0-dev1+ent_linux_386.zip"],["ent","vault_1.12.0-dev1+ent_linux_amd64.zip"],["ent","vault_1.12.0-dev1+ent_linux_arm.zip"],["ent","vault_1.12.0-dev1+ent_linux_arm64.zip"],["ent","vault_1.12.0-dev1+ent_linux_s390x.zip"],["ent","vault_1.12.0-dev1+ent_netbsd_386.zip"],["ent","vault_1.12.0-dev1+ent_netbsd_amd64.zip"],["ent","vault_1.12.0-dev1+ent_netbsd_arm.zip"],["ent","vault_1.12.0-dev1+ent_openbsd_386.zip"],["ent","vault_1.12.0-dev1+ent_openbsd_amd64.zip"],["ent","vault_1.12.0-dev1+ent_openbsd_arm.zip"],["ent","vault_1.12.0-dev1+ent_solaris_amd64.zip"],["ent","vault_1.12.0-dev1+ent_windows_386.zip"],["ent","vault_1.12.0-dev1+ent_windows_amd64.zip"],["ent","vault-enterprise_1.12.0~dev1+ent-1_amd64.deb"],["ent","vault-enterprise_1.12.0~dev1+ent-1_arm64.deb"],["ent","vault-enterprise_1.12.0~dev1+ent-1_armhf.deb"]]}