### PR TITLE
add special case for consul-k8s-control-plane-docker

### DIFF
--- a/action/metadata-support.go
+++ b/action/metadata-support.go
@@ -149,6 +149,13 @@ func correctProductNameDocker(productName string) string {
 		}
 	}
 
+	// We have to correct for a special case with consul-k8s - all docker images for this
+	// product are consul-k8s-control-plane, however their docker naming scheme uses just
+	// consul-k8s.
+	if strings.HasPrefix(newProductName, "consul-k8s") {
+		newProductName = strings.Replace(newProductName, "consul-k8s", "consul-k8s-control-plane", 1)
+	}
+
 	return newProductName
 }
 

--- a/action/metadata-support_test.go
+++ b/action/metadata-support_test.go
@@ -51,6 +51,10 @@ func TestExtractProductName(t *testing.T) {
 			name:     "consul-k8s-control-plane_0.46.0_darwin_arm64.zip",
 			expected: "consul-k8s-control-plane_0.46.0",
 		},
+		{ // consul k8s control plane docker
+			name:     "consul-k8s_ubi_linux_amd64_0.46.0_45901d13d0fddf9067ebd1cfb18854c1ef943943.docker.dev.tar",
+			expected: "consul-k8s-control-plane_0.46.0",
+		},
 
 		// vault test cases, checking both OSS and all of the possible variants of
 		// vault enterprise (hsm, fips, hsm.fips, etc)


### PR DESCRIPTION
I was made aware of a special case for consul-k8s where all docker images are the consul-k8s-control-plane product, but have "consul-k8s" as their name prefix, without the "control-plane". This adds a special case for this product so that the docker images are correctly tagged with their product name.