### PR TITLE
Rdx 565 add security scan metadata

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,0 +1,2 @@
+This file exists so that the metadata tests won't fail due to not seeing this file, 
+which is expected to exist in a full workflow run.

--- a/action/action.go
+++ b/action/action.go
@@ -184,7 +184,7 @@ func execCommand(args ...string) string {
 // importSecScanMetadata reads the security scan from file and returns
 // it b64encoded.
 func importSecScanMetadata() string {
-	secScanFilePath := ".release/security-scan.hcl"
+	const secScanFilePath = ".release/security-scan.hcl"
 
 	scanfile, err := ioutil.ReadFile(secScanFilePath)
 	if err != nil {

--- a/action/action.go
+++ b/action/action.go
@@ -27,6 +27,7 @@ type input struct {
 	securityScan     string
 	sha              string
 	version          string
+	temptest         string
 }
 
 type Metadata struct {
@@ -38,6 +39,7 @@ type Metadata struct {
 	SecurityScan    string `json:"securityScan"`
 	Revision        string `json:"sha"`
 	Version         string `json:"version"`
+	Temptest        string `json:"temptest"`
 }
 
 func main() {
@@ -51,6 +53,7 @@ func main() {
 		sha:              actions.GetInput("sha"),
 		securityScan:     importSecScanMetadata(),
 		version:          actions.GetInput("version"),
+		temptest:         "testcontent",
 	}
 	generatedFile := createMetadataJson(in)
 
@@ -131,6 +134,8 @@ func createMetadataJson(in input) string {
 	}
 	actions.Infof("Working version %v\n", version)
 
+	temptest := in.temptest
+
 	actions.Infof("Creating metadata file in %v\n", filePath)
 
 	m := &Metadata{
@@ -141,7 +146,8 @@ func createMetadataJson(in input) string {
 		Version:         version,
 		Branch:          branch,
 		Repo:            repository,
-		SecurityScan:    securityScan}
+		SecurityScan:    securityScan,
+		Temptest:        temptest}
 	output, err := json.MarshalIndent(m, "", "\t\t")
 
 	if err != nil {

--- a/action/action.go
+++ b/action/action.go
@@ -27,7 +27,6 @@ type input struct {
 	securityScan     string
 	sha              string
 	version          string
-	temptest         string
 }
 
 type Metadata struct {
@@ -39,7 +38,6 @@ type Metadata struct {
 	SecurityScan    string `json:"securityScan"`
 	Revision        string `json:"sha"`
 	Version         string `json:"version"`
-	Temptest        string `json:"temptest"`
 }
 
 func main() {
@@ -53,7 +51,6 @@ func main() {
 		sha:              actions.GetInput("sha"),
 		securityScan:     importSecScanMetadata(),
 		version:          actions.GetInput("version"),
-		temptest:         "testcontent",
 	}
 	generatedFile := createMetadataJson(in)
 
@@ -134,8 +131,6 @@ func createMetadataJson(in input) string {
 	}
 	actions.Infof("Working version %v\n", version)
 
-	temptest := in.temptest
-
 	actions.Infof("Creating metadata file in %v\n", filePath)
 
 	m := &Metadata{
@@ -146,8 +141,7 @@ func createMetadataJson(in input) string {
 		Version:         version,
 		Branch:          branch,
 		Repo:            repository,
-		SecurityScan:    securityScan,
-		Temptest:        temptest}
+		SecurityScan:    securityScan}
 	output, err := json.MarshalIndent(m, "", "\t\t")
 
 	if err != nil {

--- a/action/action.go
+++ b/action/action.go
@@ -190,11 +190,11 @@ func execCommand(args ...string) string {
 // importSecScanMetadata reads the security scan from file and returns
 // it b64encoded.
 func importSecScanMetadata() string {
-	secScanFilePath := "./release/security-scan.hcl"
+	secScanFilePath := ".release/security-scan.hcl"
 
 	scanfile, err := ioutil.ReadFile(secScanFilePath)
 	if err != nil {
-		actions.Warningf("Failure to read security scan file:", err)
+		actions.Fatalf("Failure to read security scan file:", err)
 	}
 	return (b64.StdEncoding.EncodeToString(scanfile))
 }


### PR DESCRIPTION
NOTE: NEEDS TO BE MERGED ALONG WITH RELATED CHANGE IN CRT-ORCHESTRATOR: https://github.com/hashicorp/crt-orchestrator/pull/55

### Justification

https://hashicorp.atlassian.net/browse/RDX-565

### Summary
This reads in the security-scan.hcl files and adds it as a base64 encoded string to the metadata.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

No code tests as the likely break points are dependent on system-level issues such as filepaths/file existence.
See: https://github.com/HashiCorp-RelEng-Dev/crt-workflows-common/runs/7776582960?check_suite_focus=true for a run of this branch in the dev org.


  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ x] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_