### PR TITLE
Rdx 567 add release metadata

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,2 @@
+This file exists so that the metadata tests won't fail due to not seeing this file, 
+which is expected to exist in a full workflow run.

--- a/action/action.go
+++ b/action/action.go
@@ -50,11 +50,10 @@ func main() {
 		product:          actions.GetInput("product"),
 		repo:             actions.GetInput("repository"),
 		org:              actions.GetInput("repositoryOwner"),
-		//		releaseMetadata:  importFromFile(".release/release-metadata.hcl"),
-		releaseMetadata: "teststring",
-		sha:             actions.GetInput("sha"),
-		securityScan:    importFromFile(".release/security-scan.hcl"),
-		version:         actions.GetInput("version"),
+		releaseMetadata:  importFromFile(".release/release-metadata.hcl"),
+		sha:              actions.GetInput("sha"),
+		securityScan:     importFromFile(".release/security-scan.hcl"),
+		version:          actions.GetInput("version"),
 	}
 	generatedFile := createMetadataJson(in)
 

--- a/action/action.go
+++ b/action/action.go
@@ -50,7 +50,7 @@ func main() {
 		product:          actions.GetInput("product"),
 		repo:             actions.GetInput("repository"),
 		org:              actions.GetInput("repositoryOwner"),
-		releaseMetadata:  importFromFile(".release/release-metadata.hcl"),
+		releaseMetadata:  importFromFile(".release/security-scan.hcl"),
 		sha:              actions.GetInput("sha"),
 		securityScan:     importFromFile(".release/security-scan.hcl"),
 		version:          actions.GetInput("version"),

--- a/action/action.go
+++ b/action/action.go
@@ -50,7 +50,7 @@ func main() {
 		product:          actions.GetInput("product"),
 		repo:             actions.GetInput("repository"),
 		org:              actions.GetInput("repositoryOwner"),
-		releaseMetadata:  importFromFile(".release/security-scan.hcl"),
+		releaseMetadata:  importFromFile(".release/release-metadata.hcl"),
 		sha:              actions.GetInput("sha"),
 		securityScan:     importFromFile(".release/security-scan.hcl"),
 		version:          actions.GetInput("version"),

--- a/action/action.go
+++ b/action/action.go
@@ -50,10 +50,11 @@ func main() {
 		product:          actions.GetInput("product"),
 		repo:             actions.GetInput("repository"),
 		org:              actions.GetInput("repositoryOwner"),
-		releaseMetadata:  importFromFile(".release/release-metadata.hcl"),
-		sha:              actions.GetInput("sha"),
-		securityScan:     importFromFile(".release/security-scan.hcl"),
-		version:          actions.GetInput("version"),
+		//		releaseMetadata:  importFromFile(".release/release-metadata.hcl"),
+		releaseMetadata: "teststring",
+		sha:             actions.GetInput("sha"),
+		securityScan:    importFromFile(".release/security-scan.hcl"),
+		version:         actions.GetInput("version"),
 	}
 	generatedFile := createMetadataJson(in)
 
@@ -190,7 +191,7 @@ func execCommand(args ...string) string {
 	return string(stdout.Bytes())
 }
 
-// importFromFile reads the inputted file and returns
+// importFromFile reads the inputted file from filePath and returns
 // it b64encoded.
 func importFromFile(filePath string) string {
 	scanfile, err := ioutil.ReadFile(filePath)


### PR DESCRIPTION
### Justification

[Please provide a **link** to a JIRA ticket, Slack thread, Google Doc, or other relevant documentation about the aims of this PR. If there isn't one, please state that.](https://hashicorp.atlassian.net/browse/RDX-567)

### Summary

This reads in the release-metadata.hcl file and adds it as a base64 encoded string to the metadata.
Dependent on: https://github.com/hashicorp/crt-orchestrator/pull/57

### Quality
Manually tested: https://github.com/HashiCorp-RelEng-Dev/crt-core-helloworld/actions/runs/2863779324 

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [x ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_