### PR TITLE
remove securityscan

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -32,6 +32,8 @@ type Metadata struct {
 	Org             string `json:"org"`
 	Revision        string `json:"sha"`
 	Version         string `json:"version"`
+
+	actions "github.com/sethvargo/go-githubactions"
 }
 
 func main() {

--- a/action/action.go
+++ b/action/action.go
@@ -8,10 +8,6 @@ import (
 	"os/exec"
 	"path"
 	"strings"
-
-	b64 "encoding/base64"
-
-	actions "github.com/sethvargo/go-githubactions"
 )
 
 const defaultRepositoryOwner string = "hashicorp"

--- a/action/action.go
+++ b/action/action.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+
+	actions "github.com/sethvargo/go-githubactions"
 )
 
 const defaultRepositoryOwner string = "hashicorp"
@@ -32,8 +34,6 @@ type Metadata struct {
 	Org             string `json:"org"`
 	Revision        string `json:"sha"`
 	Version         string `json:"version"`
-
-	actions "github.com/sethvargo/go-githubactions"
 }
 
 func main() {


### PR DESCRIPTION
### Justification

https://hashicorp.atlassian.net/browse/RDX-563

### Summary
This removes work from the above effort. It was discovered there is a limit of 10 fields that can be added to dispatch job, and these changes put us over that limit. We will need to revise this effort to make space for a data type that can allow us to work within this limit.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

verify step for dev org test: https://github.com/HashiCorp-RelEng-Dev/crt-workflows-common/runs/7888820991?check_suite_focus=true

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [x ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_