### PR TITLE
Rdx 565 rdx 567 additional metadata fields

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,2 @@
+This file exists so that the metadata tests won't fail due to not seeing this file, 
+which is expected to exist in a full workflow run.

--- a/action/action.go
+++ b/action/action.go
@@ -20,8 +20,10 @@ type input struct {
 	filePath         string
 	metadataFileName string
 	product          string
+	releaseMetadata  string
 	repo             string
 	org              string
+	securityScan     string
 	sha              string
 	version          string
 }
@@ -29,10 +31,12 @@ type input struct {
 type Metadata struct {
 	Branch          string `json:"branch"`
 	BuildWorkflowId string `json:"buildworkflowid"`
-	Product         string `json:"product"`
-	Repo            string `json:"repo""`
 	Org             string `json:"org"`
+	Product         string `json:"product"`
+	ReleaseMetadata string `json:"releaseMetadata"`
+	Repo            string `json:"repo""`
 	Revision        string `json:"sha"`
+	SecurityScan    string `json:"securityScan"`
 	Version         string `json:"version"`
 }
 
@@ -44,6 +48,8 @@ func main() {
 		product:          actions.GetInput("product"),
 		repo:             actions.GetInput("repository"),
 		org:              actions.GetInput("repositoryOwner"),
+		releaseMetadata:  importFromFile(".release/release-metadata.hcl"),
+		securityScan:     importFromFile(".release/security-scan.hcl"),
 		sha:              actions.GetInput("sha"),
 		version:          actions.GetInput("version"),
 	}
@@ -113,6 +119,16 @@ func createMetadataJson(in input) string {
 		actions.Fatalf("GITHUB_RUN_ID is empty")
 	}
 
+	securityScan := in.securityScan
+	if securityScan == "" {
+		actions.Warningf("Missing security scan configuration.")
+	}
+
+	releaseMetadata := in.releaseMetadata
+	if securityScan == "" {
+		actions.Warningf("Missing release metadata configuration.")
+	}
+
 	version := in.version
 	if version == "" {
 		actions.Fatalf("The version or version command is not provided")
@@ -130,7 +146,9 @@ func createMetadataJson(in input) string {
 		BuildWorkflowId: runId,
 		Version:         version,
 		Branch:          branch,
-		Repo:            repository}
+		ReleaseMetadata: releaseMetadata,
+		Repo:            repository,
+		SecurityScan:    securityScan}
 	output, err := json.MarshalIndent(m, "", "\t\t")
 
 	if err != nil {
@@ -168,4 +186,14 @@ func execCommand(args ...string) string {
 		actions.Fatalf("Failed to run %v command %v: %v", name, cmd, err)
 	}
 	return string(stdout.Bytes())
+}
+
+// importFromFile reads the inputted file from filePath and returns
+// it b64encoded.
+func importFromFile(filePath string) string {
+	scanfile, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		actions.Fatalf("Failure to read metadata from file:", err)
+	}
+	return (b64.StdEncoding.EncodeToString(scanfile))
 }

--- a/action/action.go
+++ b/action/action.go
@@ -195,7 +195,7 @@ func execCommand(args ...string) string {
 func importFromFile(filePath string) string {
 	scanfile, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		actions.Fatalf("Failure to read metadata from file:", err)
+		actions.Warningf("No file found at %v; this is unusual in builds but normal in testing pipelines.", filePath)
 	}
 	return (b64.StdEncoding.EncodeToString(scanfile))
 }

--- a/action/action.go
+++ b/action/action.go
@@ -195,7 +195,7 @@ func execCommand(args ...string) string {
 func importFromFile(filePath string) string {
 	scanfile, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		actions.Warningf("No file found at %v; this is unusual in builds but normal in testing pipelines.", filePath)
+		actions.Infof("No file found at %v; this is unusual in builds but normal in testing pipelines.", filePath)
 	}
 	return (b64.StdEncoding.EncodeToString(scanfile))
 }

--- a/action/action.go
+++ b/action/action.go
@@ -9,6 +9,8 @@ import (
 	"path"
 	"strings"
 
+	b64 "encoding/base64"
+
 	actions "github.com/sethvargo/go-githubactions"
 )
 


### PR DESCRIPTION
THIS CHANGE NEEDS TO BE MERGED SIMULTANEOUSLY WITH https://github.com/hashicorp/crt-orchestrator/pull/65

### Justification
https://hashicorp.atlassian.net/browse/RDX-567
https://hashicorp.atlassian.net/browse/RDX-565
### Summary
This change adds in metadata to read in the security-scan and release-metadata files and store them in the client_payload during orchestrator runs.

### Quality

This was tested in the dev org, you can see the metadata here: https://github.com/HashiCorp-RelEng-Dev/crt-workflows-common/actions/runs/3101644928

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ x] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_