### PR TITLE
Upgrade to go-githubactions v1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 MAINTAINER Team Rel Eng team-rel-eng@hashicorp.com
 
 # Copy all the action files into the container

--- a/action/go.mod
+++ b/action/go.mod
@@ -2,4 +2,6 @@ module github.com/hashicorp/actions-generate-metadata/action
 
 go 1.17
 
-require github.com/sethvargo/go-githubactions v0.4.0
+require github.com/sethvargo/go-githubactions v1.1.0
+
+require github.com/sethvargo/go-envconfig v0.8.2 // indirect

--- a/action/go.mod
+++ b/action/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/actions-generate-metadata/action
 
-go 1.17
+go 1.18
 
 require github.com/sethvargo/go-githubactions v1.1.0
 

--- a/action/go.sum
+++ b/action/go.sum
@@ -1,2 +1,6 @@
+github.com/sethvargo/go-envconfig v0.8.2 h1:DDUVuG21RMgeB/bn4leclUI/837y6cQCD4w8hb5797k=
+github.com/sethvargo/go-envconfig v0.8.2/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
 github.com/sethvargo/go-githubactions v0.4.0 h1:7bFG8WriSpdLgGGEnOsV87+9fi7+3Yen+YTZlw55nRQ=
 github.com/sethvargo/go-githubactions v0.4.0/go.mod h1:ugCoIFQjs7HxIwwYiY7ty6H9T+7Z4ey481HxqA3VRKE=
+github.com/sethvargo/go-githubactions v1.1.0 h1:mg03w+b+/s5SMS298/2G6tHv8P0w0VhUFaqL1THIqzY=
+github.com/sethvargo/go-githubactions v1.1.0/go.mod h1:qIboSF7yq2Qnaw2WXDsqCReM0Lo1gU4QXUWmhBC3pxE=


### PR DESCRIPTION
### Justification

The latest release of https://github.com/sethvargo/go-githubactions/releases/tag/v1.1.0 provides support for environment files for SetOutput and SaveState. Upgrading to this version will prevent this warning we're seeing across pipelines that use the action:

<img width="1216" alt="Screen Shot 2022-10-19 at 4 19 03 PM" src="https://user-images.githubusercontent.com/12939567/196822250-5060a0d2-cef4-43df-a547-6a5e4cdaebd8.png">

Using this version also requires a go version of 1.18 or above, so I made that change in the dockerfile and go mod file. 

Relates to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_