### PR TITLE
wip: Use gh vars for owner default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,12 +18,13 @@ inputs:
     description: 'The product binary name'
     required: false
   repository:
-    description: 'The repository name for collecting the metadata'
+    description: 'The repository name for collecting the metadata. Default is set to $GITHUB_REPOSITORY'
     required: true
+    default: ${{ github.repository }}
   repositoryOwner:
-    description: 'The repository owner (organization or user). Default is set to "hashicorp" organization'
+    description: 'The repository owner (organization or user). Default is set to $GITHUB_REPOSITORY_OWNER'
     required: false
-    default: 'hashicorp'
+    default: ${{ github.repository_owner }}
   version:
     description: 'Version or version command (e.g: make version)'
     required: true


### PR DESCRIPTION
### Justification

> As a user I expect the action to detect my workflow's org/repo automatically.

[Long slack thread](https://hashicorp.slack.com/archives/G01ETP58BL1/p1671571559979849)

### Summary

While attempting to add the generate-metadata step to my (project)[https://hashicorp.atlassian.net/browse/RELENG-333], I based my work on the enterprise hello-world. In the demo configuration, it does [not specify](https://github.com/hashicorp/crt-core-helloworld-enterprise/blob/main/.github/workflows/build.yml#L56) the organization (aka owner) in the inputs to the action. (Interestingly, the public/oss version [does](https://github.com/hashicorp/crt-core-helloworld/blob/main/.github/workflows/build.yml#L56)). This resulted[^1] in orchestrator in the dev organization attempting to read the production org for my repo's ci.hcl.

The error message (attached) [log-events-viewer-result.csv](https://github.com/hashicorp/actions-generate-metadata/files/10290193/log-events-viewer-result.csv) in the cloudwatch logs wasn't clear to me. Orchestrator was referencing the generate-metadata's `metadata.json` to determine where to load the `ci.hcl`, not the webhook's event data. Not knowing better, I could not understand where it was setting an `org: "hashicorp"` before even loading my`ci.hcl` which correctly specified values and I wasn't[^2] referring to the production org anywhere in my code-base.

Regardless of where orchestrator could pull the repo configuration, this change codifies a better default behavior when one triggers the generate-metadata action. By default, we use the workflow's github vars to set the org and repository. We still leave the ability to override it explicitly, but it's not clear if that's even necessary (or desired).

Caveat, this change means generate-metadata (with these implict defaults) may only be executed from the context of the product's workflows. A crt-commons-workflow execution will generate bad data.

### Quality

TBD. This is a sketch (albeit working) to discuss with @sarahethompson after the break. 

Alvin [proved](https://github.com/alvin-huang/github-input-test/actions/runs/3760032059/jobs/6390295821) the idea of using GH vars in the actions.yml to set defaults.

Config [without](https://github.com/HashiCorp-RelEng-Dev/releng-333-dekimsey-onboarding/commit/7583f657de064b6ed3668aaff0d2aa5f76304a5b) setting org [works](https://github.com/HashiCorp-RelEng-Dev/releng-333-dekimsey-onboarding/actions/runs/3760077576/jobs/6390611985).

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [x] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_

[^1]: This brought up the issue that crt-orchestrator is potentially conflating the repo information. The source of truth differs depending on what repo is triggering the webhook ($product vs crt-workflows-common). However, since the hook is triggered _first_ by a completed build workflow, it's likely the GH event is authorit. Could we instead be validating config matches? Can we support a format that doesn't require the user to copy/pasta values at all?
[^2]: Technically my .release/release-metadata.hcl did refer to production. But that was clarified to be a publishing issue and not something that should have affected orchestrator's ability to process my builds.
