### PR TITLE
Correctly detect missing metadata

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -130,7 +130,7 @@ func createMetadataJson(in input) string {
 	}
 
 	releaseMetadata := in.releaseMetadata
-	if securityScan == "" {
+	if releaseMetadata == "" {
 		actions.Warningf("Missing release metadata configuration.")
 	}
 


### PR DESCRIPTION
### Justification

Reduce confusion for anyone setting up a new project using the metadata. :-) 

### Summary

`securityScan` variable was copy/pasted twice, resulting in a warning about missing _release metadata_ even if it is present, but security scan metadata was missing.

### Quality

This PR includes:

  - [x] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_